### PR TITLE
feat: Implementacion CRUD Activity

### DIFF
--- a/src/main/java/com/example/controller/ActivityController.java
+++ b/src/main/java/com/example/controller/ActivityController.java
@@ -1,0 +1,64 @@
+package com.example.controller;
+
+import com.example.model.Activity;
+import com.example.service.ActivityService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/tasks")
+public class ActivityController {
+
+    private final ActivityService activityService;
+
+    @GetMapping
+    public ResponseEntity<Page<Activity>> listTasks(
+            @RequestParam(required = false) String filter,
+            @RequestParam(required = false) String sort,
+            @PageableDefault(size = 15) Pageable pageable) {
+
+        if (filter != null) {
+            return ResponseEntity.ok(activityService.filterByCategory(filter, pageable));
+        }
+
+        if ("priority".equalsIgnoreCase(sort)) {
+            return ResponseEntity.ok(activityService.sortByPriority(pageable));
+        }
+
+        return ResponseEntity.ok(activityService.paginate(pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Activity> getTask(@PathVariable Integer id) {
+        return ResponseEntity.ok(activityService.findById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<Activity> createTask(@RequestBody Activity activity) {
+        return new ResponseEntity<Activity>(activityService.create(activity), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Activity> updateTask(@PathVariable Integer id, @RequestBody Activity activity) {
+        return ResponseEntity.ok(activityService.update(id, activity));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Integer id) {
+        activityService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{id}/complete")
+    public ResponseEntity<Activity> markAsCompleted(@PathVariable("id") Integer id) {
+        return ResponseEntity.ok(activityService.markAsCompleted(id));
+    }
+}

--- a/src/main/java/com/example/model/Activity.java
+++ b/src/main/java/com/example/model/Activity.java
@@ -1,7 +1,8 @@
 package com.example.model;
 
 import jakarta.persistence.*;
-import jdk.jfr.Category;
+import com.example.model.Category;
+import com.example.model.User;
 import lombok.Data;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/example/repository/ActivityRespository.java
+++ b/src/main/java/com/example/repository/ActivityRespository.java
@@ -1,0 +1,12 @@
+package com.example.repository;
+
+import com.example.model.Activity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityRespository extends JpaRepository<Activity, Integer> {
+    Page<Activity> findByCategory_NameContainingIgnoreCase(String filter, Pageable pageable);
+    Page<Activity> findAllByOrderByPriorityAsc(Pageable pageable);
+}
+

--- a/src/main/java/com/example/service/ActivityService.java
+++ b/src/main/java/com/example/service/ActivityService.java
@@ -1,0 +1,20 @@
+package com.example.service;
+
+import com.example.model.Activity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface ActivityService {
+    List<Activity> getAll();
+    Page<Activity> paginate(Pageable pageable);
+    Activity findById(Integer id);
+    Activity create(Activity activity);
+    Activity update(Integer id, Activity updateActivity);
+    void delete(Integer id);
+
+    Page<Activity> filterByCategory(String courseName, Pageable pageable);
+    Page<Activity> sortByPriority(Pageable pageable);
+    Activity markAsCompleted(Integer taskId);
+}

--- a/src/main/java/com/example/service/ActivityServiceImpl.java
+++ b/src/main/java/com/example/service/ActivityServiceImpl.java
@@ -1,0 +1,84 @@
+package com.example.service;
+
+import com.example.model.Activity;
+import com.example.repository.ActivityRespository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityServiceImpl implements ActivityService {
+    private final ActivityRespository activityRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<Activity> getAll() {
+        return activityRepository.findAll();
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Activity> paginate(Pageable pageable) {
+        return activityRepository.findAll(pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Activity findById(Integer id) {
+        return activityRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Activity not found"));
+    }
+
+    @Override
+    @Transactional
+    public Activity create(Activity activity) {
+        activity.setCreatedAt(LocalDateTime.now());
+        return activityRepository.save(activity);
+    }
+
+    @Override
+    @Transactional
+    public Activity update(Integer id, Activity updateActivity) {
+        Activity activityFromDb = findById(id);
+        activityFromDb.setTitle(updateActivity.getTitle());
+        activityFromDb.setDescription(updateActivity.getDescription());
+        activityFromDb.setFinishedAt(updateActivity.getFinishedAt());
+        activityFromDb.setPriority(updateActivity.getPriority());
+        activityFromDb.setCategory(updateActivity.getCategory());
+        return activityRepository.save(activityFromDb);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Integer id) {
+        Activity activity = findById(id);
+        activityRepository.delete(activity);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Activity> filterByCategory(String courseName, Pageable pageable) {
+        return activityRepository.findByCategory_NameContainingIgnoreCase(courseName, pageable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<Activity> sortByPriority(Pageable pageable) {
+        return activityRepository.findAllByOrderByPriorityAsc(pageable);
+    }
+
+    @Override
+    @Transactional
+    public Activity markAsCompleted(Integer taskId) {
+        Activity activity = findById(taskId);
+        activity.setFinishedAt(LocalDateTime.now());
+        return activityRepository.save(activity);
+    }
+
+}
+


### PR DESCRIPTION
Este pull request añade la implementación de las operaciones CRUD (Crear, Leer, Actualizar, Eliminar) para la entidad "Activity"

Cambios Realizados
Se añadió el repositorio ActivityRepository con métodos básicos de CRUD.
Se creó el servicio 'ActivityService' y 'ActivityServicelmpl' con la lógica de negocio para gestionar categorías.
Se implementó el controlador ActivityController con endpoints REST para las operaciones CRUD.
Se realizaron las pruebas para verificar la funcionalidad del CRUD mediante Postman.